### PR TITLE
Update swagger definition content type and requestId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@mojaloop/oracle-shared-library",
-    "version": "8.5.0-snapshot",
+    "version": "8.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mojaloop/oracle-shared-library",
-    "version": "8.5.0-snapshot",
+    "version": "8.5.0",
     "description": "Shared library to create Oracles",
     "license": "Apache-2.0",
     "author": "Bank of Tanzania",
@@ -11,9 +11,6 @@
     "repository": {
         "type": "git",
         "url": "git@github.com:mojaloop/oracle-shared-library.git"
-    },
-    "config": {
-        "knex": "--knexfile ./config/knexfile.js"
     },
     "bugs": "https://github.com/mojaloop/oracle-shared-library/issues",
     "publishConfig": {

--- a/src/interface/swagger.json
+++ b/src/interface/swagger.json
@@ -707,6 +707,9 @@
         ],
         "operationId": "ParticipantsPost",
         "deprecated": false,
+        "consumes": [
+          "application/vnd.interoperability.participants+json"
+        ],
         "produces": [
           "application/json"
         ],
@@ -1017,7 +1020,8 @@
       "properties": {
         "requestId": {
           "description": "The ID of the request, decided by the client. Used for identification of the callback from the server.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "partyList": {
           "description": "List of PartyIdInfo elements that the client would like to update or create FSP information about.",

--- a/test/unit/handlers/participants.test.js
+++ b/test/unit/handlers/participants.test.js
@@ -42,7 +42,7 @@ Test('/participants', async function (participantTests) {
           path: '/participants',
           operation: 'post'
         }, function (error, mock) {
-          const newRequest = Object.assign({}, mock.request, { headers: { 'fspiop-source': 'source', date: 'date', 'Content-Type': 'application/json', accept: 'application/json' } })
+          const newRequest = Object.assign({}, mock.request, { headers: { 'fspiop-source': 'source', date: 'date', 'Content-Type': 'application/vnd.interoperability.participants+json;version=1.0', accept: 'application/vnd.interoperability.participants+json;version=1' } })
           newRequest.body.partyList = [newRequest.body.partyList[0]]
           mock.request = newRequest
 
@@ -68,7 +68,7 @@ Test('/participants', async function (participantTests) {
         options.payload = mock.request.formData
         // Set the Content-Type as application/x-www-form-urlencoded
         options.headers = options.headers || {}
-        options.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        options.headers['Content-Type'] = 'application/vnd.interoperability.participants+json;version=1.0'
         options.headers['fspiop-source'] = 'source'
       }
       // If headers are present, set the headers.


### PR DESCRIPTION
Update swagger definition to accept application/vnd.interoperability.participants+json;version=1.0 media type and make requestId mandatory field to make sure created oracle is compatible with account lookup service.